### PR TITLE
Add fuzzing and failing tests for sock_diag messages

### DIFF
--- a/netlink-packet/fuzz/Cargo.toml
+++ b/netlink-packet/fuzz/Cargo.toml
@@ -24,3 +24,4 @@ path = "fuzz_targets/netlink.rs"
 [features]
 rtnetlink = ["netlink-packet/rtnetlink"]
 audit = ["netlink-packet/audit"]
+sock_diag = ["netlink-packet/sock_diag"]

--- a/netlink-packet/fuzz/fuzz_targets/netlink.rs
+++ b/netlink-packet/fuzz/fuzz_targets/netlink.rs
@@ -20,3 +20,11 @@ fuzz_target!(|data: &[u8]| {
         let _ = <NetlinkBuffer<_> as Parseable<NetlinkMessage>>::parse(&buf);
     }
 });
+
+#[cfg(feature = "sock_diag")]
+#[rustfmt::skip]
+fuzz_target!(|data: &[u8]| {
+    if let Ok(buf) = NetlinkBuffer::new_checked(&data) {
+        let _ = <NetlinkBuffer<_> as Parseable<NetlinkMessage>>::parse(&buf);
+    }
+});

--- a/netlink-packet/src/netlink/message.rs
+++ b/netlink-packet/src/netlink/message.rs
@@ -334,6 +334,7 @@ impl Emitable for NetlinkMessage {
 mod test {
     use super::{NetlinkBuffer, NetlinkMessage, Parseable};
 
+    #[cfg(feature = "rtnetlink")]
     #[test]
     fn fuzz_bug_1() {
         let data = vec![
@@ -342,11 +343,12 @@ mod test {
             0x00, 0x3d, // flags
             0x00, 0x00, // seq number
             0xe9, 0xc8, 0x50, 0x00, // port id
-            0x0, 0x50, // invalid neighbour table message
+            0x00, 0x50, // invalid neighbour table message
         ];
         let _ = <NetlinkBuffer<_> as Parseable<NetlinkMessage>>::parse(&NetlinkBuffer::new(&data));
     }
 
+    #[cfg(feature = "rtnetlink")]
     #[test]
     fn fuzz_bug_2() {
         let data = vec![
@@ -356,6 +358,18 @@ mod test {
             0xff, 0xf7, // seq number
             0xcc, 0xc8, 0x50, 0x00, // port id
             0x00, 0x00, // invalid (error message)
+        ];
+        let _ = <NetlinkBuffer<_> as Parseable<NetlinkMessage>>::parse(&NetlinkBuffer::new(&data));
+    }
+
+    #[cfg(feature = "sock_diag")]
+    #[test]
+    fn fuzz_bug_3() {
+        let data = vec![
+            0x26, 0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x10, 0x11, 0x00, 0x00, 0xff, 0xff,
+            0xff, 0x18, 0x01, 0xff, 0x00, 0x00, 0x00, 0x10, 0xff, 0x11, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff, 0xff, 0x00, 0x00, 0x00, 0x00, 0x00, 0xff, 0xff, 0xff, 0xff, 0x18,
+            0x00, 0x1d,
         ];
         let _ = <NetlinkBuffer<_> as Parseable<NetlinkMessage>>::parse(&NetlinkBuffer::new(&data));
     }


### PR DESCRIPTION
I started fuzzing your branch, and found an issue, so here is a test:

```
$ cargo test --features sock_diag  netlink::message::test::fuzz_bug_3

[...]

---- netlink::message::test::fuzz_bug_3 stdout ----
thread 'netlink::message::test::fuzz_bug_3' panicked at 'slice index starts at 4 but ends at 0', src/libcore/slice/mod.rs:2415:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
stack backtrace:
   0: std::sys::unix::backtrace::tracing::imp::unwind_backtrace
             at src/libstd/sys/unix/backtrace/tracing/gcc_s.rs:39
   1: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:70
   2: std::panicking::default_hook::{{closure}}
             at src/libstd/sys_common/backtrace.rs:58
             at src/libstd/panicking.rs:200
   3: std::panicking::default_hook
             at src/libstd/panicking.rs:209
   4: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:478
   5: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:385
   6: rust_begin_unwind
             at src/libstd/panicking.rs:312
   7: core::panicking::panic_fmt
             at src/libcore/panicking.rs:85
   8: core::slice::slice_index_order_fail
             at src/libcore/slice/mod.rs:2415
   9: <core::ops::range::Range<usize> as core::slice::SliceIndex<[T]>>::index
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/slice/mod.rs:2584
  10: core::slice::<impl core::ops::index::Index<I> for [T]>::index
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/slice/mod.rs:2392
  11: <netlink_packet::sock_diag::buffer::RtaIterator<&'buffer T> as core::iter::traits::iterator::Iterator>::next
             at netlink-packet/src/sock_diag/buffer.rs:605
  12: <core::iter::adapters::Map<I, F> as core::iter::traits::iterator::Iterator>::next
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/iter/adapters/mod.rs:567
  13: <<core::result::Result<V, E> as core::iter::traits::collect::FromIterator<core::result::Result<A, E>>>::from_iter::Adapter<Iter, E> as core::iter::traits::iterator::Iterator>::next
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/result.rs:1220
  14: <&mut I as core::iter::traits::iterator::Iterator>::next
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/iter/traits/iterator.rs:2731
  15: <alloc::vec::Vec<T> as alloc::vec::SpecExtend<T, I>>::from_iter
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/liballoc/vec.rs:1813
  16: <alloc::vec::Vec<T> as core::iter::traits::collect::FromIterator<T>>::from_iter
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/liballoc/vec.rs:1725
  17: <core::result::Result<V, E> as core::iter::traits::collect::FromIterator<core::result::Result<A, E>>>::from_iter
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/result.rs:1237
  18: core::iter::traits::iterator::Iterator::collect
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/iter/traits/iterator.rs:1466
  19: netlink_packet::sock_diag::message::<impl netlink_packet::traits::Parseable<netlink_packet::sock_diag::message::UnixDiagResponse> for netlink_packet::sock_diag::buffer::UnixDiagMsgBuffer<T>>::parse
             at netlink-packet/src/sock_diag/message.rs:367
  20: netlink_packet::sock_diag::message::SockDiagMessage::parse
             at netlink-packet/src/sock_diag/message.rs:61
  21: netlink_packet::netlink::message::<impl netlink_packet::traits::Parseable<netlink_packet::netlink::message::NetlinkMessage> for netlink_packet::netlink::buffer::NetlinkBuffer<&'buffer T>>::parse
             at netlink-packet/src/netlink/message.rs:271
  22: netlink_packet::netlink::message::test::fuzz_bug_3
             at netlink-packet/src/netlink/message.rs:374
  23: netlink_packet::netlink::message::test::fuzz_bug_3::{{closure}}
             at netlink-packet/src/netlink/message.rs:367
  24: core::ops::function::FnOnce::call_once
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/ops/function.rs:231
  25: <F as alloc::boxed::FnBox<A>>::call_box
             at src/libtest/lib.rs:1474
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libcore/ops/function.rs:231
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/liballoc/boxed.rs:734
  26: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:92
  27: test::run_test::run_test_inner::{{closure}}
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libstd/panicking.rs:276
             at /rustc/147311c5fc62537da8eb9c6f69536bec6719d534/src/libstd/panic.rs:388
             at src/libtest/lib.rs:1429
```